### PR TITLE
bump zig version to v0.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Why install tree from homebrew when you can rewrite it from scratch?
 
 - Display directory structures in a tree-like format
 - Custom sorting logic:
-  - Hidden files first (when enabled)
-  - Uppercase files/directories first
-  - Directories before files
-  - Alphanumeric sorting
+    - Hidden files first (when enabled)
+    - Uppercase files/directories first
+    - Directories before files
+    - Alphanumeric sorting
 - Command-line flags to customize behavior
 - Memory-safe implementation using Zig
 
@@ -19,7 +19,7 @@ Why install tree from homebrew when you can rewrite it from scratch?
 
 ### Requirements
 
-- Zig language (0.14.0 or later recommended)
+- Zig language (0.15.2 or later recommended)
 
 ### Building from Source
 
@@ -53,24 +53,28 @@ Basic usage:
 ### Command Line Options
 
 | Flag   | Long Form       | Description                                |
-|--------|-----------------|--------------------------------------------|
+| ------ | --------------- | ------------------------------------------ |
 | `-a`   | `--all`         | Show hidden files (starting with `.`)      |
 | `-L n` | `--max-depth n` | Limit directory recursion to n levels deep |
-| 
+
+|
 
 ## Examples
 
 Show all files including hidden ones:
+
 ```bash
 ./tree -a
 ```
 
 Limit directory depth to 2 levels:
+
 ```bash
 ./tree -L 2
 ```
 
 Combine options:
+
 ```bash
 ./tree -a -L 3 ~/Documents
 ```
@@ -101,15 +105,14 @@ tree
 └── tree.zig
 ```
 
-
 ## Differences from Standard Tree
 
 - Optimized for macOS
 - Custom sorting algorithm prioritizing:
-  1. Hidden files (when shown)
-  2. Uppercase items
-  3. Directories
-  4. Alphanumeric order
+    1. Hidden files (when shown)
+    2. Uppercase items
+    3. Directories
+    4. Alphanumeric order
 
 ## License
 

--- a/build.zig
+++ b/build.zig
@@ -1,77 +1,38 @@
 const std = @import("std");
 
-// Although this function looks imperative, note that its job is to
-// declaratively construct a build graph that will be executed by an external
-// runner.
 pub fn build(b: *std.Build) void {
-    // Standard target options allows the person running `zig build` to choose
-    // what target to build for. Here we do not override the defaults, which
-    // means any target is allowed, and the default is native. Other options
-    // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
-
-    // Standard optimization options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
-    // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    // We will also create a module for our other entry point, 'main.zig'.
     const exe_mod = b.createModule(.{
-        // `root_source_file` is the Zig "entry point" of the module. If a module
-        // only contains e.g. external object files, you can make this `null`.
-        // In this case the main source file is merely a path, however, in more
-        // complicated build scripts, this could be a generated file.
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
 
-    // This creates another `std.Build.Step.Compile`, but this one builds an executable
-    // rather than a static library.
     const exe = b.addExecutable(.{
         .name = "tree",
         .root_module = exe_mod,
     });
 
-    // This declares intent for the executable to be installed into the
-    // standard location when the user invokes the "install" step (the default
-    // step when running `zig build`).
     b.installArtifact(exe);
 
-    // This *creates* a Run step in the build graph, to be executed when another
-    // step is evaluated that depends on it. The next line below will establish
-    // such a dependency.
     const run_cmd = b.addRunArtifact(exe);
-
-    // By making the run step depend on the install step, it will be run from the
-    // installation directory rather than directly from within the cache directory.
-    // This is not necessary, however, if the application depends on other installed
-    // files, this ensures they will be present and in the expected location.
     run_cmd.step.dependOn(b.getInstallStep());
 
-    // This allows the user to pass arguments to the application in the build
-    // command itself, like this: `zig build run -- arg1 arg2 etc`
     if (b.args) |args| {
         run_cmd.addArgs(args);
     }
 
-    // This creates a build step. It will be visible in the `zig build --help` menu,
-    // and can be selected like this: `zig build run`
-    // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    // Creates a step for unit testing. This only builds the test executable
-    // but does not run it.
-    const exe_unit_tests = b.addTest(.{
+    const unit_tests = b.addTest(.{
         .root_module = exe_mod,
     });
 
-    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+    const run_artifact_tests = b.addRunArtifact(unit_tests);
 
-    // Similar to creating the run step earlier, this exposes a `test` step to
-    // the `zig build --help` menu, providing a way for the user to request
-    // running the unit tests.
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&run_exe_unit_tests.step);
+    test_step.dependOn(&run_artifact_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -28,7 +28,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.2",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/installer.sh
+++ b/installer.sh
@@ -1,71 +1,71 @@
 #!/bin/bash
 
 # Installer script for Tree Clone
-# This script will install the Zig Tree Clone to ~/.local/bin
+# This script will install  Zig Tree to ~/.local/bin
 
 set -e  # Exit immediately if a command exits with a non-zero status
 
-echo "📂 Tree Clone Installer"
+echo "Tree Installer"
 echo "=========================="
 
-VERSION="0.14.0"
+ZIG_VERSION="0.15.2"
 
 # Function to download and install Zig if not found
 install_zig() {
-    echo "🔍 Zig not found. Installing from official binary..."
-    
+    echo "Zig not found. Installing from official binary..."
+
     # Create temporary directory for Zig download
     ZIG_TEMP=$(mktemp -d)
-    
+
     # Determine system architecture
     ARCH=$(uname -m)
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-    
+
     # Set appropriate URL based on architecture
     if [[ "$ARCH" == "x86_64" ]]; then
         if [[ "$OS" == "darwin" ]]; then
-            ZIG_URL="https://ziglang.org/download/${VERSION}/zig-macos-x86_64-${VERSION}.tar.xz"
+            ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-macos-x86_64-${ZIG_VERSION}.tar.xz"
         elif [[ "$OS" == "linux" ]]; then
-            ZIG_URL="https://ziglang.org/download/${VERSION}/zig-linux-x86_64-${VERSION}.tar.xz"
+            ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
         fi
     elif [[ "$ARCH" == "arm64" || "$ARCH" == "aarch64" ]]; then
         if [[ "$OS" == "darwin" ]]; then
-            ZIG_URL="https://ziglang.org/download/${VERSION}/zig-macos-aarch64-${VERSION}.tar.xz"
+            ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-macos-aarch64-${ZIG_VERSION}.tar.xz"
         elif [[ "$OS" == "linux" ]]; then
-            ZIG_URL="https://ziglang.org/download/${VERSION}/zig-linux-aarch64-${VERSION}.tar.xz"
+            ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-linux-aarch64-${ZIG_VERSION}.tar.xz"
         fi
     fi
-    
+
     if [[ -z "$ZIG_URL" ]]; then
         echo "❌ Could not determine appropriate Zig download for your system."
         echo "   Please download and install Zig manually from https://ziglang.org/download/"
         rm -rf "$ZIG_TEMP"
         exit 1
     fi
-    
-    echo "📥 Downloading Zig from $ZIG_URL"
-    
+
+    echo "Downloading Zig from $ZIG_URL"
+
     # Download Zig
     if ! curl -L "$ZIG_URL" -o "$ZIG_TEMP/zig.tar.xz"; then
         echo "❌ Failed to download Zig. Please check your internet connection."
         rm -rf "$ZIG_TEMP"
         exit 1
     fi
-    
+
     # Extract Zig
-    ZIG_DIR="${HOME}/.zig-${VERSION}"
+    ZIG_DIR="${HOME}/.zig-${ZIG_VERSION}"
     mkdir -p "${ZIG_DIR}"
-    echo "📦 Extracting Zig to ${ZIG_DIR}"
+    echo "Extracting Zig to ${ZIG_DIR}"
     tar -xf "$ZIG_TEMP/zig.tar.xz" -C "$ZIG_DIR"
-    
+
     # Copy Zig binary to ~/.local/bin
-    echo "📦 Installing Zig to ~/.local/bin/"
+    echo "Installing Zig to ~/.local/bin/"
     mkdir -p "$HOME/.local/bin/"
     ln -s "${ZIG_DIR}/zig" "${HOME}/.local/bin/"
-    
+
     # Add ~/.local/bin to PATH if not already there
     if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-        echo "⚠️ Adding ~/.local/bin to your PATH"
+        echo "Adding ~/.local/bin to your PATH"
         echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
         echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.profile"
         if [[ -f "$HOME/.zshrc" ]]; then
@@ -73,12 +73,12 @@ install_zig() {
         fi
         export PATH="$HOME/.local/bin:$PATH"
     fi
-    
-    echo "✅ Zig installed to ~/.local/bin/"
-    
+
+    echo "Zig installed to ~/.local/bin/"
+
     # Clean up
     rm -rf "$ZIG_TEMP"
-    
+
     # Test if Zig is working
     if ! command -v zig &> /dev/null; then
         echo "❌ Zig installation failed. Please add ~/.local/bin to your PATH and try again."
@@ -92,18 +92,18 @@ install_dir() {
 
     # Ensure installation directory is in PATH
     if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
-        echo "⚠️ Warning: $INSTALL_DIR is not in your PATH."
-        echo "   Adding it to your PATH configuration files..."
-        
+        echo "Warning: $INSTALL_DIR is not in your PATH."
+        echo "Adding zig to your PATH configuration files..."
+
         # Add to common shell configuration files
         echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
         echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.profile"
-        
+
         # Add to zsh config if it exists
         if [[ -f "$HOME/.zshrc" ]]; then
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zshrc"
         fi
-        
+
         echo "   Please restart your terminal or run: export PATH=\"$HOME/.local/bin:\$PATH\""
     fi
 }
@@ -112,14 +112,14 @@ install_dir() {
 if ! command -v zig &> /dev/null; then
     install_zig
 else
-    echo "✅ Zig is already installed"
+    echo "Zig is already installed"
 fi
 
 zig build
 
 # Install to ~/.local/bin
-INSTALL_DIR="$HOME/.zig-${VERSION}"
-echo "📦 Installing to $INSTALL_DIR/tree..."
+INSTALL_DIR="$HOME/.zig-${ZIG_VERSION}"
+echo "Installing to $INSTALL_DIR/tree..."
 
 install_dir
 
@@ -128,4 +128,4 @@ BUILD_OUTPUT="${PWD}/zig-out/bin/tree"
 cp "$BUILD_OUTPUT" "$INSTALL_DIR/tree"
 chmod +x "$INSTALL_DIR/tree"
 
-echo "✅ Installation complete"
+echo "Installation complete"


### PR DESCRIPTION
## Summary by Sourcery

Refactor tree printing logic to support generic writers while updating tooling and docs for Zig 0.15.2.

New Features:
- Allow tree output to be directed to an arbitrary writer instead of printing directly to stdout.

Enhancements:
- Extract directory entry sorting into a reusable helper to simplify recursion logic.
- Simplify the build script and test wiring to align with newer Zig build APIs.

Build:
- Update build.zig to use the current test invocation style for Zig 0.15.2.

Documentation:
- Update README to recommend Zig 0.15.2 and fix minor formatting issues.

Tests:
- Adjust directory traversal tests to assert against in-memory writer output instead of relying on stdout.

Chores:
- Update the installer script to download and install Zig 0.15.2 and refresh user-facing messages.