### PR TITLE
build: add zlinter and style build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,19 @@ cd tree
 # Build the executable
 zig build
 
-# test the code
+# format code
+zig build fmt
+
+# lint code
+zig build lint
+
+# format and lint code
+zig build style
+
+# test all code
+zig build test
+
+# test the code of one module
 zig test tree.zig
 
 # Optional: Move to a directory in your PATH

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -36,45 +36,11 @@
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
     .dependencies = .{
-        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
-        //.example = .{
-        //    // When updating this field to a new URL, be sure to delete the corresponding
-        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
-        //    // the new URL. If the contents of a URL change this will result in a hash mismatch
-        //    // which will prevent zig from using it.
-        //    .url = "https://example.com/foo.tar.gz",
-        //
-        //    // This is computed from the file contents of the directory of files that is
-        //    // obtained after fetching `url` and applying the inclusion rules given by
-        //    // `paths`.
-        //    //
-        //    // This field is the source of truth; packages do not come from a `url`; they
-        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
-        //    // obtain a package matching this `hash`.
-        //    //
-        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
-        //    .hash = "...",
-        //
-        //    // When this is provided, the package is found in a directory relative to the
-        //    // build root. In this case the package's hash is irrelevant and therefore not
-        //    // computed. This field and `url` are mutually exclusive.
-        //    .path = "foo",
-        //
-        //    // When this is set to `true`, a package is declared to be lazily
-        //    // fetched. This makes the dependency only get fetched if it is
-        //    // actually used.
-        //    .lazy = false,
-        //},
+        .zlinter = .{
+            .url = "git+https://github.com/kurtwagner/zlinter?ref=0.15.x#59129bb0ca1efecd3b6625def6dc527cead4caac",
+            .hash = "zlinter-0.0.1-OjQ08ZOnCwBx9meqm2cUjOkYUBeTUpKhQ3ERnVPg6ARc",
+        },
     },
-
-    // Specifies the set of files and directories that are included in this package.
-    // Only files and directories listed here are included in the `hash` that
-    // is computed for this package. Only files listed here will remain on disk
-    // when using the zig package manager. As a rule of thumb, one should list
-    // files required for compilation plus any license(s).
-    // Paths are relative to the build root. Use the empty string (`""`) to refer to
-    // the build root itself.
-    // A directory listed here means that all files within, recursively, are included.
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
- Add `zlinter` dependency and configure `lint` step with all built-in rules.
- Add `fmt` step to run `zig fmt`.
- Add `style` step to run both `lint` and `fmt`.
- Resolve linter warnings:
  - Replace deprecated `GeneralPurposeAllocator` with `DebugAllocator`.
  - Replace deprecated `ArrayList.writer` with `std.io.Writer.Allocating`.
  - Add missing doc comments and fix inferred error unions.
- Fix compilation error in tests related to `AllocatingWriter` usage.
- Update README with new build commands.
- Add `ci` build step to run `style` and `test`

## Summary by Sourcery

Add style-related build steps, integrate zlinter, and update code and docs to satisfy new linting and formatting requirements.

New Features:
- Add lint, fmt, style, and ci build steps to the Zig build configuration.

Bug Fixes:
- Fix tests to use std.io.Writer.Allocating instead of deprecated ArrayList.writer and resolve related compilation issues.

Enhancements:
- Replace deprecated GeneralPurposeAllocator usage with DebugAllocator and adjust main signature for inferred error unions.
- Adopt zlinter with all built-in rules in the build pipeline for linting.

Documentation:
- Update README to document new build commands for formatting, linting, style checks, and running tests.